### PR TITLE
fixed IKFast code generator template to fit MoveIt interface

### DIFF
--- a/templates/ikfast61_moveit_plugin_template.cpp
+++ b/templates/ikfast61_moveit_plugin_template.cpp
@@ -88,7 +88,6 @@ public:
    * @param ik_seed_state an initial guess solution for the inverse kinematics
    * @param solution the solution vector
    * @param error_code an error code that encodes the reason for failure or success
-   * @param lock_redundant_joints ?
    * @return True if a valid solution was found, false otherwise
    */
 
@@ -97,7 +96,7 @@ public:
                      const std::vector<double> &ik_seed_state,
                      std::vector<double> &solution,
                      moveit_msgs::MoveItErrorCodes &error_code,
-                     bool lock_redundant_joints = false) const;
+                     const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.
@@ -112,7 +111,7 @@ public:
                         double timeout,
                         std::vector<double> &solution,
                         moveit_msgs::MoveItErrorCodes &error_code,
-                        bool lock_redundant_joints = false) const;
+			const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.
@@ -129,7 +128,7 @@ public:
                         const std::vector<double> &consistency_limits,
                         std::vector<double> &solution,
                         moveit_msgs::MoveItErrorCodes &error_code,
-                        bool lock_redundant_joints = false) const;
+			const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.
@@ -145,7 +144,7 @@ public:
                         std::vector<double> &solution,
                         const IKCallbackFn &solution_callback,
                         moveit_msgs::MoveItErrorCodes &error_code,
-                        bool lock_redundant_joints = false) const;
+			const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.
@@ -164,7 +163,7 @@ public:
                         std::vector<double> &solution,
                         const IKCallbackFn &solution_callback,
                         moveit_msgs::MoveItErrorCodes &error_code,
-                        bool lock_redundant_joints = false) const;
+			const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a set of joint angles and a set of links, compute their pose
@@ -558,7 +557,7 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
                                            double timeout,
                                            std::vector<double> &solution,
                                            moveit_msgs::MoveItErrorCodes &error_code,
-                                           bool lock_redundancy) const
+                                           const kinematics::KinematicsQueryOptions &options) const
 {
   const IKCallbackFn solution_callback = 0; 
   std::vector<double> consistency_limits;
@@ -570,7 +569,7 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
                           solution,
                           solution_callback,
                           error_code,
-                          lock_redundancy);
+                          options);
 }
     
 bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
@@ -579,7 +578,7 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
                                            const std::vector<double> &consistency_limits,
                                            std::vector<double> &solution,
                                            moveit_msgs::MoveItErrorCodes &error_code,
-                                           bool lock_redundancy) const
+                                           const kinematics::KinematicsQueryOptions &options) const
 {
   const IKCallbackFn solution_callback = 0; 
   return searchPositionIK(ik_pose,
@@ -589,7 +588,7 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
                           solution,
                           solution_callback,
                           error_code,
-                          lock_redundancy);
+                          options);
 }
 
 bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
@@ -598,7 +597,7 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
                                            std::vector<double> &solution,
                                            const IKCallbackFn &solution_callback,
                                            moveit_msgs::MoveItErrorCodes &error_code,
-                                           bool lock_redundancy) const
+                                           const kinematics::KinematicsQueryOptions &options) const
 {
   std::vector<double> consistency_limits;
   return searchPositionIK(ik_pose,
@@ -608,7 +607,7 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
                           consistency_limits,
                           solution_callback,
                           error_code,
-                          lock_redundancy);
+                          options);
 }
 
 bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
@@ -618,7 +617,7 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
                                               std::vector<double> &solution,
                                               const IKCallbackFn &solution_callback,
                                               moveit_msgs::MoveItErrorCodes &error_code,
-                                              bool lock_redundant_joints) const
+                                              const kinematics::KinematicsQueryOptions &options) const
 {
   ROS_DEBUG_STREAM_NAMED("ikfast","searchPositionIK");
 
@@ -788,7 +787,7 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose &ik_pose,
                                            const std::vector<double> &ik_seed_state,
                                            std::vector<double> &solution,
                                            moveit_msgs::MoveItErrorCodes &error_code,
-                                           bool lock_redundant_joints) const
+                                           const kinematics::KinematicsQueryOptions &options) const
 {
   ROS_DEBUG_STREAM_NAMED("ikfast","getPositionIK");
 


### PR DESCRIPTION
IKFast code generated from template threw compiler errors because the method signatures did not reflect the changes in the MoveIt interface
