### PR TITLE
Fix issue #18: remove install rule for ikfast.h from generated package CMakeLists.txt

### DIFF
--- a/templates/CMakeLists.txt
+++ b/templates/CMakeLists.txt
@@ -33,7 +33,6 @@ add_library(${IKFAST_LIBRARY_NAME} src/_ROBOT_NAME___GROUP_NAME__ikfast_moveit_p
 target_link_libraries(${IKFAST_LIBRARY_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${LAPACK_LIBRARIES})
 
 install(TARGETS ${IKFAST_LIBRARY_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
-install(DIRECTORY include/ DESTINATION include)
 
 install(
   FILES


### PR DESCRIPTION
AFAICT the `ikfast.h` header is only needed for compilation of the MoveIt IKFast plugin, not by 'end-users' of the resulting binary (library or package).
