### PR TITLE
Fix issue #21: move catkin pkgs to catkin_depends in generated CMakeLists

### DIFF
--- a/templates/CMakeLists.txt
+++ b/templates/CMakeLists.txt
@@ -16,11 +16,11 @@ link_directories(${catkin_LIBRARY_DIRS})
 
 catkin_package(
   LIBRARIES
-  DEPENDS
-  moveit_core
-  pluginlib
-  roscpp
-  tf_conversions
+  CATKIN_DEPENDS
+    moveit_core
+    pluginlib
+    roscpp
+    tf_conversions
 )
 
 include_directories(include)


### PR DESCRIPTION
As per subject.
