### PR TITLE
Fixes for 23, 27 and 28

### DIFF
--- a/scripts/create_ikfast_moveit_plugin.py
+++ b/scripts/create_ikfast_moveit_plugin.py
@@ -275,7 +275,7 @@ if __name__ == '__main__':
       return missing_deps
 
    # empty sets evaluate to false
-   modified_pkg = (update_deps(build_deps, "build_depend", package_xml.getroot()) and
+   modified_pkg = (update_deps(build_deps, "build_depend", package_xml.getroot()) or
                      update_deps(run_deps, "run_depend", package_xml.getroot()))
 
    if modified_pkg:

--- a/scripts/create_ikfast_moveit_plugin.py
+++ b/scripts/create_ikfast_moveit_plugin.py
@@ -264,7 +264,7 @@ if __name__ == '__main__':
    package_xml = etree.parse(package_file_name, parser)
 
    # Make sure at least all required dependencies are in the depends lists
-   build_deps = ["cmake_modules", "moveit_core", "pluginlib", "roscpp", "tf_conversions"]
+   build_deps = ["moveit_core", "pluginlib", "roscpp", "tf_conversions"]
    run_deps   = ["moveit_core", "pluginlib", "roscpp", "tf_conversions"]
 
    def update_deps(reqd_deps, req_type, e_parent):

--- a/scripts/create_ikfast_moveit_plugin.py
+++ b/scripts/create_ikfast_moveit_plugin.py
@@ -263,25 +263,20 @@ if __name__ == '__main__':
    package_file_name = plugin_pkg_dir+"/package.xml"
    package_xml = etree.parse(package_file_name, parser)
 
-   # Check that all the dependencies are in the depends list
-   modified_pkg = False
-   for dependency in ["moveit_core", "pluginlib", "roscpp", "tf_conversions"]:
-      found = False
-      for depend_entry in package_xml.getroot().findall("build_depend"):
-         if depend_entry.text == dependency:
-            found = True
-            break  
-      if not found:    
-         modified_pkg = True
-         # Build depend
-         child = etree.Element("build_depend")
-         child.text = dependency
-         package_xml.getroot().append(child)
+   # Make sure at least all required dependencies are in the depends lists
+   build_deps = ["cmake_modules", "moveit_core", "pluginlib", "roscpp", "tf_conversions"]
+   run_deps   = ["moveit_core", "pluginlib", "roscpp", "tf_conversions"]
 
-         # Run depend
-         child = etree.Element("run_depend")
-         child.text = dependency
-         package_xml.getroot().append(child)
+   def update_deps(reqd_deps, req_type, e_parent):
+      curr_deps = [e.text for e in e_parent.findall(req_type)]
+      missing_deps = set(reqd_deps) - set(curr_deps)
+      for d in missing_deps:
+         etree.SubElement(e_parent, req_type).text = d
+      return missing_deps
+
+   # empty sets evaluate to false
+   modified_pkg = (update_deps(build_deps, "build_depend", package_xml.getroot()) and
+                     update_deps(run_deps, "run_depend", package_xml.getroot()))
 
    if modified_pkg:
       with open(package_file_name,"w") as f:

--- a/templates/CMakeLists.txt
+++ b/templates/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(_PACKAGE_NAME_)
 
-find_package(Eigen REQUIRED)
-include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
-
 find_package(catkin REQUIRED COMPONENTS
+  cmake_modules
   moveit_core
   pluginlib
   roscpp
@@ -26,6 +24,9 @@ catkin_package(
 include_directories(include)
 
 set(IKFAST_LIBRARY_NAME _LIBRARY_NAME_)
+
+find_package(Eigen REQUIRED)
+include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
 
 find_package(LAPACK REQUIRED)
 

--- a/templates/CMakeLists.txt
+++ b/templates/CMakeLists.txt
@@ -10,7 +10,6 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 include_directories(${catkin_INCLUDE_DIRS})
-link_directories(${catkin_LIBRARY_DIRS})
 
 catkin_package(
   LIBRARIES

--- a/templates/CMakeLists.txt
+++ b/templates/CMakeLists.txt
@@ -36,7 +36,7 @@ install(TARGETS ${IKFAST_LIBRARY_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_
 
 install(
   FILES
-  _ROBOT_NAME__moveit_ikfast_plugin_description.xml
+  _ROBOT_NAME___GROUP_NAME__moveit_ikfast_plugin_description.xml
   DESTINATION
   ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/templates/CMakeLists.txt
+++ b/templates/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(_PACKAGE_NAME_)
 
 find_package(catkin REQUIRED COMPONENTS
-  cmake_modules
   moveit_core
   pluginlib
   roscpp
@@ -23,9 +22,6 @@ catkin_package(
 include_directories(include)
 
 set(IKFAST_LIBRARY_NAME _LIBRARY_NAME_)
-
-find_package(Eigen REQUIRED)
-include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
 
 find_package(LAPACK REQUIRED)
 


### PR DESCRIPTION
These commits contain proposed fixes for the referenced issues.

I've had to update the way `create_ikfast_moveit_plugin.py` works with package dependencies, as `cmake_modules` is only a `build_depend`.
