### PR TITLE
Search for cheapest IK solution

### DIFF
--- a/scripts/create_ikfast_moveit_plugin.py
+++ b/scripts/create_ikfast_moveit_plugin.py
@@ -52,6 +52,8 @@ from lxml import etree
 import shutil
 
 plugin_gen_pkg = 'moveit_ikfast'  # package containing this file
+# Allowed search modes, see SEARCH_MODE enum in template file
+search_modes = ['OPTIMIZE_MAX_JOINT', 'OPTIMIZE_FREE_JOINT' ]
 
 if __name__ == '__main__':
    # Check input arguments
@@ -59,10 +61,20 @@ if __name__ == '__main__':
       robot_name = sys.argv[1]
       planning_group_name = sys.argv[2]
       moveit_plugin_pkg = sys.argv[3]
-      ikfast_output_file = sys.argv[4]
-      assert( len(sys.argv) < 6 )   # invalid num-arguments
+      if len(sys.argv) == 6:
+         ikfast_output_file = sys.argv[5]
+         search_mode = sys.argv[4]
+         if search_mode not in search_modes:
+            print 'Invalid search mode. Allowed values: ', search_modes
+            raise Exception()
+      elif len(sys.argv) == 5:
+         search_mode = search_modes[0];
+         print "Warning: The default search has changed from OPTIMIZE_FREE_JOINT to now %s!" % (search_mode)
+         ikfast_output_file = sys.argv[4]
+      else:
+         raise Exception()  
    except:
-      print("\nUsage: create_ikfast_plugin.py <yourrobot_name> <planning_group_name> <moveit_plugin_pkg> ikfast_output_path>\n")
+      print("\nUsage: create_ikfast_plugin.py <yourrobot_name> <planning_group_name> <moveit_plugin_pkg> [<search_mode>] <ikfast_output_path>\n")
       sys.exit(-1)
    print '\nIKFast Plugin Generator'
 
@@ -208,6 +220,7 @@ if __name__ == '__main__':
    template_text = template_file_data.read()
    template_text = re.sub('_ROBOT_NAME_', robot_name, template_text)
    template_text = re.sub('_GROUP_NAME_', planning_group_name, template_text)
+   template_text = re.sub('_SEARCH_MODE_', search_mode, template_text)
    plugin_file_base = robot_name + '_' + planning_group_name + '_ikfast_moveit_plugin.cpp'
 
    plugin_file_name = plugin_pkg_dir + '/src/' + plugin_file_base

--- a/templates/ikfast61_moveit_plugin_template.cpp
+++ b/templates/ikfast61_moveit_plugin_template.cpp
@@ -838,12 +838,14 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
             {
               // Costs for solution: Largest joint motion
               double costs = 0.0;
-              for(unsigned int i = 0; i < solution.size(); i++) {
+              for(unsigned int i = 0; i < solution.size(); i++)
+              {
                 double d = fabs(ik_seed_state[i] - solution[i]);
                 if (d > costs)
                   costs = d;
               }
-              if (costs < best_costs || best_costs == -1.0) {
+              if (costs < best_costs || best_costs == -1.0)
+              {
                 best_costs = costs;
                 best_solution = solution;
               }
@@ -869,7 +871,8 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
 
   ROS_DEBUG_STREAM_NAMED("ikfast", "Valid solutions: " << nvalid << "/" << nattempts);
 
-  if (search_best && best_costs != -1.0) {
+  if (search_best && best_costs != -1.0)
+  {
     solution = best_solution;
     error_code.val = error_code.SUCCESS;
     return true;

--- a/templates/ikfast61_moveit_plugin_template.cpp
+++ b/templates/ikfast61_moveit_plugin_template.cpp
@@ -831,7 +831,7 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
       }
     }
 
-    if(!getCount(counter, num_positive_increments, num_negative_increments))
+    if(!getCount(counter, num_positive_increments, -num_negative_increments))
     {
       error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
       return false;


### PR DESCRIPTION
- searchPositionIK() returned the first collision-free solution within joint limits it finds. (The free joint is moved as little as possible.) This approach regularly leads to large and ugly motions in joint space even for small displacements of the EE, see video [1]. Instead, the solution with the smallest costs should be returned. Here, the largest motion of any joint is taken as the cost term. Trajectories become much smoother, see video [2].
- Due to the speed of IK fast, it is ok to search the entire search space. However, if callbacks for collision checking are used, a coarse-to-fine search scheme might be needed.
- getCount() was called with a positive third argument. Thus, no search in negative direction was performed.

[1] https://www.youtube.com/watch?v=-VX709r0N2Y
[2] https://www.youtube.com/watch?v=BFpG8TY6aqk
