### PR TITLE
Reduce INFO output at initialization

### DIFF
--- a/templates/ikfast61_moveit_plugin_template.cpp
+++ b/templates/ikfast61_moveit_plugin_template.cpp
@@ -364,7 +364,7 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
   std::reverse(joint_has_limits_vector_.begin(), joint_has_limits_vector_.end());
 
   for(size_t i=0; i <num_joints_; ++i)
-    ROS_INFO_STREAM_NAMED("ikfast",joint_names_[i] << " " << joint_min_vector_[i] << " " << joint_max_vector_[i] << " " << joint_has_limits_vector_[i]);
+    ROS_DEBUG_STREAM_NAMED("ikfast",joint_names_[i] << " " << joint_min_vector_[i] << " " << joint_max_vector_[i] << " " << joint_has_limits_vector_[i]);
 
   active_ = true;
   return true;


### PR DESCRIPTION
There is too much output to INFO when IKFast loads. This PR removes:

```
 INFO ros.baxter_ikfast_left_arm_plugin.ikfast: left_s0 -1.70168 1.70168 1
 INFO ros.baxter_ikfast_left_arm_plugin.ikfast: left_s1 -2.147 1.047 1
 INFO ros.baxter_ikfast_left_arm_plugin.ikfast: left_e0 -3.05418 3.05418 1
 INFO ros.baxter_ikfast_left_arm_plugin.ikfast: left_e1 -0.05 2.618 1
 INFO ros.baxter_ikfast_left_arm_plugin.ikfast: left_w0 -3.059 3.059 1
 INFO ros.baxter_ikfast_left_arm_plugin.ikfast: left_w1 -1.5708 2.094 1
 INFO ros.baxter_ikfast_left_arm_plugin.ikfast: left_w2 -3.059 3.059 1
```
