### PR TITLE
Added Timeout to searchPositionIK(...)

### DIFF
--- a/templates/ikfast61_moveit_plugin_template.cpp
+++ b/templates/ikfast61_moveit_plugin_template.cpp
@@ -870,6 +870,13 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
       break;
     }
 
+    if (ros::Time::now() > maxTime)
+    {
+      ROS_DEBUG_STREAM_NAMED("ikfast", "IK search exceeded search time of " << timeout << " seconds");
+      error_code.val = moveit_msgs::MoveItErrorCodes::TIMED_OUT;
+      break;
+    }
+
     vfree[0] = initial_guess+search_discretization_*counter;
     //ROS_DEBUG_STREAM_NAMED("ikfast","Attempt " << counter << " with 0th free joint having value " << vfree[0]);
   }

--- a/templates/ikfast61_moveit_plugin_template.cpp
+++ b/templates/ikfast61_moveit_plugin_template.cpp
@@ -890,8 +890,6 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
     return true;
   }
 
-  // No solution found
-  error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
   return false;
 }
 


### PR DESCRIPTION
The interface for searchPositionIK includes a timeout argument. A timeout variable is even created inside the function (`maxTime`) but is never used. I added a check to see if the time was exceeded after finishing a round of discretizations. 

This both satisfies an interface requirement that is not addressed at the moment (time out) and will ensure that the plugin doesn't freeze even if it has to do a bunch of collision checking. As mentioned in #43, the cheapest solution is usually found upfront anyway and this PR shouldn't affect that.

Argh:

I meant to make this against indigo-devel, but I believe this still applies. 
