### PR TITLE
Harmonize Not Using Harmonized Values

### DIFF
--- a/templates/ikfast61_moveit_plugin_template.cpp
+++ b/templates/ikfast61_moveit_plugin_template.cpp
@@ -470,16 +470,16 @@ double IKFastKinematicsPlugin::harmonize(const std::vector<double> &ik_seed_stat
     while(ss[i] > 2*M_PI) {
       ss[i] -= 2*M_PI;
     }
-    while(ss[i] < 2*M_PI) {
+    while(ss[i] < 2*-M_PI) {
       ss[i] += 2*M_PI;
     }
     while(solution[i] > 2*M_PI) {
       solution[i] -= 2*M_PI;
     }
-    while(solution[i] < 2*M_PI) {
+    while(solution[i] < 2*-M_PI) {
       solution[i] += 2*M_PI;
     }
-    dist_sqr += fabs(ik_seed_state[i] - solution[i]);
+    dist_sqr += fabs(ss[i] - solution[i]);
   }
   return dist_sqr;
 }


### PR DESCRIPTION
The `harmonize` function appears to `adjust`  joint values to be inside the -2Pi to 2Pi range. To this end, it copies the passed in `ik_seed_state` and computes an adjusted version of it `ss`. This variable is currently never used and in calculating the squared distance, the original is used instead.

I assume this is a bug, so here's the fix. I've tested it locally and the plugin seems to work but I'd be curious for the input of others. 

Also, should the joint range be [-2 Pi, 2 Pi] or [- Pi, Pi ]?
