### PR TITLE
Kinematics base update

### DIFF
--- a/templates/ikfast61_moveit_plugin_template.cpp
+++ b/templates/ikfast61_moveit_plugin_template.cpp
@@ -299,6 +299,12 @@ private:
   void fillFreeParams(int count, int *array);
   bool getCount(int &count, const int &max_count, const int &min_count) const;
 
+  /**
+  * @brief samples the designated redundant joint using the chosen discretization method
+  * @param  method              An enumeration flag indicating the discretization method to be used
+  * @param  sampled_joint_vals  Sampled joint values for the redundant joint
+  * @return True if sampling succeeded.   
+  */
   bool sampleRedundantJoint(kinematics::DiscretizationMethod method, std::vector<double>& sampled_joint_vals) const;
 
 }; // end class
@@ -1143,9 +1149,11 @@ bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Found " << numsol << " solutions from IKFast");
   bool solutions_found = false;
-  std::stringstream ss;
   if( numsol > 0 )
   {
+    /*
+      Iterating through all solution sets and storing those that do not exceed joint limits.
+    */
     for(unsigned int r = 0; r < solution_set.size() ; r++)
     {
 
@@ -1155,14 +1163,6 @@ bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose
       {
         std::vector<double> sol;
         getSolution(ik_solutions,s,sol);
-        ss.str("");
-        ss<<"[";
-        for(unsigned int i = 0 ; i < sol.size() ; i++)
-        {
-          ss<<sol[i]<<" ";
-        }
-        ss<<"]";
-        ROS_DEBUG_NAMED("ikfast","Sol %d: %s", s, ss.str().c_str());
 
         bool obeys_limits = true;
         for(unsigned int i = 0; i < sol.size(); i++)

--- a/templates/ikfast61_moveit_plugin_template.cpp
+++ b/templates/ikfast61_moveit_plugin_template.cpp
@@ -329,7 +329,7 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
   {
     redundant_joint_indices_.clear();
     redundant_joint_indices_.push_back(free_params_[0]);
-    KinematicsBase::setSearchDiscretization(0);
+    KinematicsBase::setSearchDiscretization(DEFAULT_SEARCH_DISCRETIZATION);
   }
 
   urdf::Model robot_model;
@@ -445,6 +445,13 @@ void IKFastKinematicsPlugin::setSearchDiscretization(const std::map<int,double>&
                      redundant_joint<<"' with index " <<redundant_joint_indices_[0]<<" is redundant.");
     return;
   }
+
+  if(discretization.begin()->second <= 0.0)
+  {
+	  ROS_ERROR_STREAM("Discretization can not takes values that are <= 0");
+	  return;
+  }
+
 
   redundant_joint_discretization_.clear();
   redundant_joint_discretization_[redundant_joint_indices_[0]] = discretization.begin()->second;

--- a/templates/ikfast61_moveit_plugin_template.cpp
+++ b/templates/ikfast61_moveit_plugin_template.cpp
@@ -164,6 +164,7 @@ public:
    * 'getPositionIK(...)' with a zero initialized seed.
    *
    * @param ik_poses  The desired pose of each tip link
+   * @param ik_seed_state an initial guess solution for the inverse kinematics
    * @param solutions A vector of vectors where each entry is a valid joint solution
    * @param result A struct that reports the results of the query
    * @param options An option struct which contains the type of redundancy discretization used. This default
@@ -1221,9 +1222,10 @@ bool IKFastKinematicsPlugin::sampleRedundantJoint(kinematics::DiscretizationMeth
       break;
     case kinematics::DiscretizationMethods::ALL_RANDOM_SAMPLED:
     {
-      int count = joint_dscrt > 1 ? static_cast<int>(joint_dscrt) : 1;
+      int steps = std::ceil((joint_max - joint_min)/joint_dscrt);
+      steps = steps > 0 ? steps : 1;
       double diff = joint_max - joint_min;
-      for(int i = 0; i < count; i++)
+      for(int i = 0; i < steps; i++)
       {
         sampled_joint_vals.push_back( ((diff*std::rand())/(static_cast<double>(RAND_MAX))) + joint_min );
       }


### PR DESCRIPTION
This PR addresses the issue discussed in #56 
In a nutshell, this PR updates the ikfast template so that it overloads the **getPositionIk(...)** method in the **moveit_core::KinematicsBase** class that returns multiple solutions.
@gavanderhoorn please review
